### PR TITLE
Fix example mistake

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ npm install node-openweather
 var weather = require('node-openweather')({
   key: "your-openweathermap-api-key",
   accuracy: "like",
-  unit: "metric",
+  units: "metric",
   language: "en"
 });
 


### PR DESCRIPTION
The correct form is "units" and no "unit".
